### PR TITLE
Shared killpoints, lobby leader

### DIFF
--- a/bulwark/purchase.sqf
+++ b/bulwark/purchase.sqf
@@ -21,7 +21,7 @@ _vechAi    = (BULWARK_BUILDITEMS select _index) select 7;
 // Script was passed an invalid number
 if(_shopClass == "") exitWith {};
 
-private _killPoints = call killPoints_fnc_get;
+private _killPoints = [player] call killPoints_fnc_get;
 if(_killPoints >= _shopPrice && !(player getVariable "buildItemHeld")) then {
     [player, _shopPrice] remoteExec ["killPoints_fnc_spend", 2];
     if (_vechAi) then {

--- a/description.ext
+++ b/description.ext
@@ -72,9 +72,16 @@ class CfgRemoteExec
 		class createBlur {};
 		class suiExplode{};
 
+		class BIS_fnc_endMissionServer {};
+
 		class lobby_fnc_startGame {};
 		class server_fnc_startServer {};
 		class player_fnc_startPlayer {};
+
+		class killPoints_fnc_change {};
+		class killPoints_fnc_add {};
+		class killPoints_fnc_spend {};
+		class killPoints_fnc_updateHud {};
 	};
 };
 

--- a/lobby/lobby.sqf
+++ b/lobby/lobby.sqf
@@ -7,7 +7,7 @@
 **/
 #include "..\shared\defines.hpp"
 
-if (!isNil "leadSurvivor") then {
+if (player == leader (group player)) then {
 	[format ["Loading parameters from player: %1", player], "LOBBY"] call shared_fnc_log;
 	private _selectedParameterSet = call shared_fnc_loadSelectedParameterSet;
 	CurrentBulwarkParams = [_selectedParameterSet, PARAMSET_TYPE_CUSTOM] call shared_fnc_loadParameterSet;
@@ -35,7 +35,7 @@ lobbyCrate addAction [
 	false, // showWindow
 	true, // hideOnUse
 	"", // shortCut
-	"!isNil 'leadSurvivor'" // Confition
+	"player == leader (group player)" // Confition
 ];
 
 lobbyCrate addAction [
@@ -46,7 +46,7 @@ lobbyCrate addAction [
 	false, // showWindow
 	true, // hideOnUse
 	"", // shortCut
-	"!isNil 'leadSurvivor'" // Confition
+	"player == leader (group player)" // Confition
 ];
 
 lobbyCrate addAction [
@@ -57,7 +57,7 @@ lobbyCrate addAction [
 	false, // showWindow
 	true, // hideOnUse
 	"", // shortCut
-	"!isNil 'leadSurvivor'" // Condition
+	"player == leader (group player)" // Condition
 ];
 
 
@@ -72,5 +72,5 @@ lobbyCrate addAction [
 	true, // showWindow
 	true, // hideOnUse
 	"", // shortCut
-	"isNil 'leadSurvivor'" // condition
+	"player != leader (group player)" // condition
 ];

--- a/mission.sqm
+++ b/mission.sqm
@@ -245,7 +245,6 @@ class Mission
 					flags=3;
 					class Attributes
 					{
-						name="leadSurvivor";
 						description="Lead Survivor";
 						isPlayable=1;
 					};

--- a/player/functions/fn_initPlayer.sqf
+++ b/player/functions/fn_initPlayer.sqf
@@ -61,13 +61,7 @@ endLoadingScreen;
 player setVariable ["RevByMedikit", false, true];
 player setVariable ["buildItemHeld", false];
 
-//setup Kill Points
-_killPoints = player getVariable "killPoints";
-if(isNil "_killPoints") then {
-    _killPoints = 0;
-};
-
-player setVariable ["killPoints", _killPoints, true];
+// Update killpoints hud
 [] call killPoints_fnc_updateHud;
 
 /*

--- a/score/Functions.hpp
+++ b/score/Functions.hpp
@@ -3,9 +3,10 @@ class killPoints
     class globals
     {
         file = "score\functions";
-        class init {postInit = 1;};
+        class init {};
         class get {};
         class add {};
+        class change {};
         class spend {};
         class hit {};
         class killed {};

--- a/score/functions/fn_add.sqf
+++ b/score/functions/fn_add.sqf
@@ -1,26 +1,22 @@
 /**
 *  fn_add
 *
-*  Adds score to the specified player
+* Adds points from the specified player. Server authoritative
+* to allow for shared points.
 *
-*  Domain: Server
+*  Domain: Any
 **/
 #include "..\..\shared\bulwark.hpp"
 
 params ["_player", "_points"];
 
 if (isServer) then {
-	switch (KILLPOINTS_MODE) do {
-		case KILLPOINTS_MODE_PRIVATE: {
-			_killPoints = call killPoints_fnc_get;
-			_killPoints = round (_killPoints + _points);
-			_player setVariable ["killPoints", _killPoints, true];
-		};
-		case KILLPOINTS_MODE_SHARED: {
-		};
-		case KILLPOINTS_MODE_SHAREABLE: {
-		};
-	};
+	//format ["%1 Adding %2 points", _player, _points] call shared_fnc_log;
+	private _killPoints = [_player] call killPoints_fnc_get;
+	private _killPoints = round (_killPoints + _points);
 
-	[] remoteExec ["killPoints_fnc_updateHud", _player];
+	// Perform the actual change on the server
+	[_player, _killPoints] call killPoints_fnc_change;
+} else {
+	[_player, _points] remoteExecCall ["killPoints_fnc_add", 2];
 };

--- a/score/functions/fn_change.sqf
+++ b/score/functions/fn_change.sqf
@@ -1,0 +1,27 @@
+/**
+*  fn_change
+*
+* Changes the killpoints to the specified value. If this is a shared points
+* mode, every player gets the points.  Otherwise only the specified player
+* gets the points. This will trigger a hud update
+*
+*  Domain: Server
+**/
+#include "..\..\shared\bulwark.hpp"
+
+params ["_player", "_killPoints"];
+
+if (isServer) then {
+	//format ["%1 Changing killpoints to %2", _player, _killPoints] call shared_fnc_log;
+	if (KILLPOINTS_MODE == KILLPOINTS_MODE_SHARED) then {
+		{
+			_x setVariable ["killPoints", _killPoints, true];
+			[] remoteExec ["killPoints_fnc_updateHud", _x];
+		} forEach allPlayers;
+	} else {
+		_player setVariable ["killPoints", _killPoints, true];
+		[] remoteExec ["killPoints_fnc_updateHud", _player];
+	};
+} else {
+	["Called killPoints_fnc_change on a non-server", "ERR"] call shared_fnc_log;
+};

--- a/score/functions/fn_get.sqf
+++ b/score/functions/fn_get.sqf
@@ -1,18 +1,26 @@
-#include "..\..\shared\bulwark.hpp"
+/**
+*  fn_gets
+*
+* Gets the killpoints for the current player.  If the points are
+* shared, all players have the same value. Otherwise gets the specified
+* player's points.
+*
+*  Domain: Any
+**/
 
-private _killPoints = 0;
-if (!isnil "KILLPOINTS_MODE") then {
-    switch (KILLPOINTS_MODE) do {
-        case KILLPOINTS_MODE_PRIVATE: {
-            _killPoints = player getVariable "killPoints";
-            if(isNil "_killPoints") then {
-                _killPoints = 0;
-            };
-        };
-        case KILLPOINTS_MODE_SHARED: {
-        };
-        case KILLPOINTS_MODE_SHAREABLE: {
-        };
+params ["_player"];
+
+if (isServer || (_player == player)) then {
+    private _killPoints = 0;
+    _killPoints = _player getVariable "killPoints";
+    if(isNil "_killPoints") then {
+        _killPoints = 0;
     };
+
+    //format ["Getting KPs: %1 %2", _player, _killPoints] call shared_fnc_log;
+
+    _killPoints;
+} else {
+    // Cannot get another player's points from this player
+    [_player] remoteExecCall ["killPoints_fnc_get", 2];
 };
-_killPoints;

--- a/score/functions/fn_init.sqf
+++ b/score/functions/fn_init.sqf
@@ -3,9 +3,17 @@
 *
 *  Initialize the score system
 *
-*  Domain: Client
+*  Domain: Server
 **/
 
-if (!isDedicated) then {
-	[] call killPoints_fnc_updateHud;
+#include "..\..\shared\bulwark.hpp"
+
+if (KILLPOINTS_MODE == KILLPOINTS_MODE_SHARED) then {
+  // Add initial killpoints for everyone by virtue of adding it to the first player
+  [allPlayers select 0, BULWARK_PARAM_START_KILLPOINTS call shared_fnc_getCurrentParamValue] call killPoints_fnc_add;
+} else {
+  {
+    // Current result is saved in variable _x
+    [_x, BULWARK_PARAM_START_KILLPOINTS call shared_fnc_getCurrentParamValue] call killPoints_fnc_add;
+  } forEach allPlayers;
 };

--- a/score/functions/fn_spend.sqf
+++ b/score/functions/fn_spend.sqf
@@ -1,30 +1,23 @@
 /**
-*  fn_spend
+*  fn_add
 *
-*  Subtract from specified players score if the player has the score
+* Subtracts points from the specified player. Server authoritative
+* to allow for shared points.
 *
-*  Domain: Server
+*  Domain: Any
 **/
 #include "..\..\shared\bulwark.hpp"
 
 params ["_player", "_points"];
 
 if (isServer) then {
-	switch (KILLPOINTS_MODE) do {
-		case KILLPOINTS_MODE_PRIVATE: {
-			_killPoints = call killPoints_fnc_get;
-
-			// REVIEW: It would be weird to fail this condition...
-			if(_killPoints - _points >= 0) then {
-				_killPoints = _killPoints - _points;
-				_player setVariable ["killPoints", _killPoints, true];
-			};
-		};
-		case KILLPOINTS_MODE_SHARED: {
-		};
-		case KILLPOINTS_MODE_SHAREABLE: {
-		};
+	private _killPoints = [_player] call killPoints_fnc_get;
+	if(_killPoints - _points >= 0) then {
+		_killPoints = _killPoints - _points;
 	};
 
-	[] remoteExec ["killPoints_fnc_updateHud", _player];
-};
+	// Perform the actual change on the server
+	[_player, _killPoints] call killPoints_fnc_change;
+} else {
+	[_player, _points] call killPoints_fnc_spend;
+}

--- a/score/functions/fn_updateHud.sqf
+++ b/score/functions/fn_updateHud.sqf
@@ -10,7 +10,7 @@ if (!isDedicated) then {
     disableSerialization;
     _player = player;
 
-    _killPoints = call killPoints_fnc_get;
+    _killPoints = [_player] call killPoints_fnc_get;
 
     _attackWave = 0;
     if(!isNil "attkWave") then {

--- a/server/functions/fn_startServer.sqf
+++ b/server/functions/fn_startServer.sqf
@@ -85,11 +85,7 @@ HITMARKERPARAM = (BULWARK_PARAM_HUD_POINT_HITMARKERS call shared_fnc_getCurrentP
 publicVariable 'HITMARKERPARAM';
 
 // Broadcast the starting killpoints for everyone
-{
-  // Current result is saved in variable _x
-  [_x, BULWARK_PARAM_START_KILLPOINTS call shared_fnc_getCurrentParamValue] call killPoints_fnc_add;
-} forEach allPlayers;
-
+call killPoints_fnc_init;
 
 _dayTimeHours = DAY_TIME_TO - DAY_TIME_FROM;
 _randTime = floor random _dayTimeHours;

--- a/shared/functions/fn_getDefaultParams.sqf
+++ b/shared/functions/fn_getDefaultParams.sqf
@@ -7,6 +7,15 @@
 // These parameters should be specified in the order they will be displayed, and grouped by
 // their category.
 //
+//
+// Parameter format:
+// <parameter id>,
+// <parameter title>, <parameter category name>, <parameter type>, <is multi-select>,
+// <array of options which are title-value pairs>,
+// <default value, or values if multi-select>,
+// <long description of the parameter>
+//
+
 private _defaultBulwarkParams = [ 
 	//
 	// PARAM_CATEGORY_FILTERS

--- a/supports/functions/fn_supplyDrop.sqf
+++ b/supports/functions/fn_supplyDrop.sqf
@@ -42,7 +42,6 @@ supplyDropLatch = false;
 // Set the radius to be a percentage of the Bulwark radius - the drop will happen somewhere
 // within this area
 private _supplyDropRadius = BULWARK_RADIUS * LOOT_SUPPLYDROP;
-format ["Supply drop radius from bulwark: %1", _supplyDropRadius] call shared_fnc_log;
 _waypoint0 = _ag addwaypoint[_dropTarget,_supplyDropRadius];
 _waypoint0 setwaypointtype "Move";
 

--- a/supports/purchase.sqf
+++ b/supports/purchase.sqf
@@ -18,7 +18,7 @@ if  (SUPPORTMENU) then {
   // Script was passed an invalid number
   if(_shopClass == "") exitWith {};
 
-  if((call killPoints_fnc_get) >= _shopPrice) then {
+  if(([player] call killPoints_fnc_get) >= _shopPrice) then {
       [player, _shopPrice] remoteExec ["killPoints_fnc_spend", 2];
       [player, _shopClass] call BIS_fnc_addCommMenuItem;
   } else {


### PR DESCRIPTION
The shared killpoints feature is now enabled.  In this mode, all killpoints are shared by all players.  The Shareable killpoints feature is not part of this feature.
In the lobby, the group leader is now in control, not the person in slot 1.
Added a comment to describe the parameter format.