### PR TITLE
Add IDs to options, season selection, time multiplier

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,10 @@
 * Progressived spawning (cap on how many units can spawn at once, trickle them in over time)
 * Broaden search for valid starting houses/loot houses.
 * Use CBA logging mechanism: https://github.com/CBATeam/CBA_A3/wiki/Error-handling
+
+# Possible new wave types?
 * Enemy paratroopers?
+* Player extract to win (after set amount of waves, or purchasing an extraction from the Bulwark)
 
 # DONE
 * FIXED HandleDamage registered each time the player respawns

--- a/TODO.md
+++ b/TODO.md
@@ -6,16 +6,16 @@
 * missionLoop is a tight while loop
 * The number of units at higher end waves is crunching the game.  We need to spread it out.
 * Drone waves spawn too many drones, its frustrating players.  Drones would be better as additions to existing waves as a distraction.
+* The supply drop plane was behaving very strangely after the wave numbers got higher - it could take several flyby's before the crate dropped.
 
 # New Features
-* Parameter options should be indexed by a unique option ID, not by array index
 * AI target buildings with grenades/explosives
   * Needs investigation - destroy waypoints
   * We already have activation radius for suicide bombers - extend to explosives specialists to opportunistically plant explosives next to your constructions
   * Extend to bulwark to make it destructible
   * Audio or visual cue that bulwark is under threat
   * Explosives on timer, use new disarm functionality to mitigate
-* Faction-based enemies
+* TIWAZ Faction-based enemies
 * Tweak spawn list to remove backpacks and other useless spawn items
 * Spawn groups instead of individuals?
 * Spawns between waves?
@@ -41,4 +41,4 @@
 * DONE Scaling vehicle waves (maybe with a vehicle costing table and wave budget), https://community.bistudio.com/wiki/CfgVehicles_Config_Reference#cost
 * DONE UI Support for multiple-selection options
 * DONE Team-wide bulwark points
-
+* DONE Parameter options should be indexed by a unique option ID, not by array index

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,11 @@
 # Bugs
-* Long start time for some waves
 * Vehicles stick around based on timer, not wave
 * Player corpses stick around based on timer
 * Guns sometimes get removed when accessing gear
-* missionLoop is a tight while loop
 * The number of units at higher end waves is crunching the game.  We need to spread it out.
 * Drone waves spawn too many drones, its frustrating players.  Drones would be better as additions to existing waves as a distraction.
 * The supply drop plane was behaving very strangely after the wave numbers got higher - it could take several flyby's before the crate dropped.
+  * Supply drop plane also tends to hit the mountain side.  Maybe use a helicopter?  Slower and more accurate.
 
 # New Features
 * AI target buildings with grenades/explosives
@@ -21,8 +20,9 @@
 * Spawns between waves?
 * "Shareable" bulwark points (player can choose to give another player some of their points)
 * Progressived spawning (cap on how many units can spawn at once, trickle them in over time)
-* Broaden search for valid starting houses/loot houses.
+* Broaden search for valid starting houses/loot houses.  Seems like we are always getting the same couple of cities
 * Use CBA logging mechanism: https://github.com/CBATeam/CBA_A3/wiki/Error-handling
+* Ability to sell back items (User suggested)
 
 # Possible new wave types?
 * Enemy paratroopers?
@@ -45,3 +45,5 @@
 * DONE Parameter options should be indexed by a unique option ID, not by array index
 * DONE Play at different times of the year?
 * DONE Ability to set time multiplier (for faster day/night cycles)
+* FIXED Long start time for some waves
+* FIXED missionLoop is a tight while loop

--- a/TODO.md
+++ b/TODO.md
@@ -19,8 +19,6 @@
 * Tweak spawn list to remove backpacks and other useless spawn items
 * Spawn groups instead of individuals?
 * Spawns between waves?
-* Play at different times of the year?
-* Slower transition to night time using time acceleration?
 * "Shareable" bulwark points (player can choose to give another player some of their points)
 * Progressived spawning (cap on how many units can spawn at once, trickle them in over time)
 * Broaden search for valid starting houses/loot houses.
@@ -45,3 +43,5 @@
 * DONE UI Support for multiple-selection options
 * DONE Team-wide bulwark points
 * DONE Parameter options should be indexed by a unique option ID, not by array index
+* DONE Play at different times of the year?
+* DONE Ability to set time multiplier (for faster day/night cycles)

--- a/description.ext
+++ b/description.ext
@@ -76,6 +76,7 @@ class CfgRemoteExec
 
 		class lobby_fnc_startGame {};
 		class server_fnc_startServer {};
+		class server_fnc_registerPlayer {};
 		class player_fnc_startPlayer {};
 
 		class killPoints_fnc_change {};

--- a/lobby/functions/fn_populateDialogParams.sqf
+++ b/lobby/functions/fn_populateDialogParams.sqf
@@ -47,7 +47,7 @@ private _currentCategory = "";
       _optionValue = "";
       {
         private _value = _x;
-        private _option = PARAM_GET_OPTION_BY_INDEX(_param, _value);
+        private _option = PARAM_GET_OPTION_BY_ID(_param, _value);
         if (!isNil "_option") then {
           if (_optionValue != "") then {
             _optionValue = _optionValue + ", ";
@@ -57,7 +57,7 @@ private _currentCategory = "";
       } forEach PARAM_GET_VALUE(_param);
     } else {
       // DROPDOWN
-      private _option = PARAM_GET_OPTION_BY_INDEX(_param, PARAM_GET_VALUE(_param));
+      private _option = PARAM_GET_OPTION_BY_ID(_param, PARAM_GET_VALUE(_param));
       _optionValue = PARAM_GET_OPTION_NAME(_option);
     };
   };

--- a/lobby/functions/fn_showChangeParamDialog.sqf
+++ b/lobby/functions/fn_showChangeParamDialog.sqf
@@ -37,7 +37,8 @@ if (_isMultiSelect) then {
       _selectControl lbAdd PARAM_GET_OPTION_NAME(_x);
     } forEach PARAM_GET_OPTIONS(_param);
 
-    _selectControl lbSetCurSel PARAM_GET_VALUE(_param);
+    private _selectedOptionIndex = PARAM_GET_OPTION_INDEX_FOR_ID(_param, PARAM_GET_VALUE(_param));
+    _selectControl lbSetCurSel _selectedOptionIndex;
   } else {
     // EDIT CONTROL
     createDialog "bulwarkParamEdit_Dialog";

--- a/lobby/functions/fn_showChangeParamDialog.sqf
+++ b/lobby/functions/fn_showChangeParamDialog.sqf
@@ -24,7 +24,7 @@ if (_isMultiSelect) then {
     private _rowControls = (_row select 1);
     (_rowControls select 0) ctrlSetBackgroundColor [0, 0, 0, 0.3];
     (_rowControls select 2) ctrlSetText PARAM_GET_OPTION_NAME(_x);
-    private _isSelected = PARAM_GET_OPTION_VALUE(_x) in _selectedValues;
+    private _isSelected = PARAM_GET_OPTION_ID(_x) in _selectedValues;
     (_rowControls select 1) cbSetChecked _isSelected;
   } forEach _options;
 } else {

--- a/lobby/functions/fn_startGame.sqf
+++ b/lobby/functions/fn_startGame.sqf
@@ -4,5 +4,6 @@ publicVariable "CurrentBulwarkParams";
 // Start the server
 remoteExec ["server_fnc_startServer", 2];
 
-// Start the players
+// Start the players.  This will also get run every
+// time a player joins.
 remoteExec ["player_fnc_startPlayer", 0, true];

--- a/lobby/functions/fn_updateParamFromDialog.sqf
+++ b/lobby/functions/fn_updateParamFromDialog.sqf
@@ -19,14 +19,16 @@ private _newParamValue = if (_isMultiSelect) then {
     private _rowControls = _editControl ctRowControls _x;
     private _checkbox = _rowControls select 1;
     if (cbChecked _checkbox) then {
-      _selectedValues pushBack _x;
+      private _option = PARAM_GET_OPTION_BY_INDEX(_param, _x);
+      _selectedValues pushBack PARAM_GET_OPTION_ID(_option);
     };
   };
   _selectedValues;
 } else {
   if (_hasOptions) then {
     // DROPDOWN
-    lbCurSel _editControl;
+    private _option = PARAM_GET_OPTION_BY_INDEX(_param, lbCurSel _editControl);
+    PARAM_GET_OPTION_ID(_option);
   } else {
     // EDIT CONTROL
     (ctrlText 100) call shared_fnc_getNumberFromString;

--- a/player/functions/fn_initPlayer.sqf
+++ b/player/functions/fn_initPlayer.sqf
@@ -1,9 +1,4 @@
 // This function is called once when the game starts (after the lobby)
-initStarted = nil;
-gameStarted = nil;
-
-// TODO: Refactor, probably remove initStarted too
-//waitUntil {!isNil "initStarted"};
 
 player setDamage 0;
 
@@ -60,9 +55,6 @@ endLoadingScreen;
 
 player setVariable ["RevByMedikit", false, true];
 player setVariable ["buildItemHeld", false];
-
-// Update killpoints hud
-[] call killPoints_fnc_updateHud;
 
 /*
 // Delete all map markers on clients

--- a/player/functions/fn_startPlayer.sqf
+++ b/player/functions/fn_startPlayer.sqf
@@ -1,6 +1,6 @@
 // This should be a scheduled environment
 
 if (hasInterface) then {
+    player remoteExec ["server_fnc_registerPlayer", 2];
     call player_fnc_initPlayer;
 };
-

--- a/score/functions/fn_updateHud.sqf
+++ b/score/functions/fn_updateHud.sqf
@@ -6,7 +6,7 @@
 *  Domain: Client
 **/
 
-if (!isDedicated) then {
+if (hasInterface) then {
     disableSerialization;
     _player = player;
 

--- a/server/Functions.hpp
+++ b/server/Functions.hpp
@@ -7,5 +7,6 @@ class server
         class missionLoop {};
         class setParams {};
         class setLocations {};
+        class registerPlayer {};
     };
 };

--- a/server/functions/fn_missionLoop.sqf
+++ b/server/functions/fn_missionLoop.sqf
@@ -46,28 +46,24 @@ while {runMissionLoop} do {
 	while {runMissionLoop} do {
 		sleep 1; // We don't need to update this very often
 
-		// Get all human players in this wave cycle
-		// moved to contain players that respawned in this wave
-		_allHCs = entities "HeadlessClient_F";
-		_allHPs = allPlayers - _allHCs;
-
 		//Check if all hostiles dead
 		if (EAST countSide allUnits == 0) exitWith {};
 
 		_respawnTickets = [west] call BIS_fnc_respawnTickets;
 		if(_respawnTickets <= 0) then {
 			// Players will lose the game if they are all dead or unconscious
+
+			// Get all human players in this wave cycle
+			// moved to contain players that respawned in this wave
+			_allHCs = entities "HeadlessClient_F";
+			_allHPs = allPlayers - _allHCs;
+
 			private _deadOrUnconscious = _allHPs select { (!alive _x) || ((lifeState _x) == "INCAPACITATED") };
 			if (count _deadOrUnconscious >= count _allHPs) then {
 				runMissionLoop = false;
 				missionFailure = true;
 				"End1" call BIS_fnc_endMissionServer;
-			}
-		} else {
-			// Ensure all players are in curator
-			{
-				mainZeus addCuratorEditableObjects [[_x], true];
-			} foreach _allHPs;
+			};
 		};
 	};
 

--- a/server/functions/fn_missionLoop.sqf
+++ b/server/functions/fn_missionLoop.sqf
@@ -35,8 +35,6 @@ missionFailure = false;
 // start in build phase
 missionNamespace setVariable ["buildPhase", true, true];
 
-[west, RESPAWN_TICKETS] call BIS_fnc_respawnTickets;
-
 while {runMissionLoop} do {
 
 	//Reset the AI position checks

--- a/server/functions/fn_registerPlayer.sqf
+++ b/server/functions/fn_registerPlayer.sqf
@@ -1,0 +1,4 @@
+params ["_player"];
+
+mainZeus addCuratorEditableObjects [[_player], true];
+format ["Player %1 registered", _player] call shared_fnc_log;

--- a/server/functions/fn_setLocations.sqf
+++ b/server/functions/fn_setLocations.sqf
@@ -14,11 +14,16 @@ if("bulwark" in _arr) then {
     };
 } foreach allMapMarkers;
 
+private _locationTypes = (BULWARK_PARAM_LOCATIONS call shared_fnc_getCurrentParamValue);
+if (count _locationTypes == 0) then {
+    _locationTypes = ["NameCityCapital", "NameCity", "Airport"];
+};
+
 _allLocations = [];
 {
     _allLocations append [locationPosition _x];
     format ["Added location %1", locationPosition _x] call shared_fnc_log;
-} forEach nearestLocations [[0,0,0], ["NameCity", "NameCityCapital", "Airport"], 40000];
+} forEach nearestLocations [[0,0,0], _locationTypes, 40000];
 
 _locationParameter = BULWARK_PARAM_BULWARK_POSITION call shared_fnc_getCurrentParamValue;
 if (_locationParameter == 1 && count _zoneMarkers != 0 && _markerSetup) then {

--- a/server/functions/fn_setParams.sqf
+++ b/server/functions/fn_setParams.sqf
@@ -25,9 +25,13 @@ KILLPOINTS_MODE = (BULWARK_PARAM_KILLPOINTS_MODE call shared_fnc_getCurrentParam
 SCORE_KILL = (BULWARK_PARAM_SCORE_KILL call shared_fnc_getCurrentParamValue);                 // Base Points for a kill
 SCORE_HIT = (BULWARK_PARAM_SCORE_HIT call shared_fnc_getCurrentParamValue);                   // Every Bullet hit that doesn't result in a kill
 SCORE_DAMAGE_BASE = (BULWARK_PARAM_SCORE_DAMAGE_BASE call shared_fnc_getCurrentParamValue);   // Extra points awarded for damage. 100% = SCORE_DAMAGE_BASE. 50% = SCORE_DAMAGE_BASE/2
+
 /* Time of Day*/
 DAY_TIME_FROM = (BULWARK_PARAM_DAY_TIME_FROM call shared_fnc_getCurrentParamValue);
 DAY_TIME_TO = (BULWARK_PARAM_DAY_TIME_TO call shared_fnc_getCurrentParamValue);
+SEASON = (BULWARK_PARAM_SEASON call shared_fnc_getCurrentParamValue);
+TIME_MULTIPLIER = (BULWARK_PARAM_TIME_MULTIPLIER call shared_fnc_getCurrentParamValue);
+
 // Check for sneaky inverted configuration. FROM should always be before TO.
 if (DAY_TIME_FROM > DAY_TIME_TO) then {
     DAY_TIME_FROM = DAY_TIME_TO - 2;

--- a/server/functions/fn_startServer.sqf
+++ b/server/functions/fn_startServer.sqf
@@ -1,10 +1,5 @@
 #include "..\..\shared\bulwark.hpp"
 
-// TODO: Refactor into a function
-
-initStarted = true;
-publicVariable "initStarted";
-
 // variable to prevent players rejoining during a wave
 playersInWave = [];
 publicVariable "playersInWave";
@@ -84,7 +79,8 @@ publicVariable 'TEAM_DAMAGE';
 HITMARKERPARAM = (BULWARK_PARAM_HUD_POINT_HITMARKERS call shared_fnc_getCurrentParamValue);
 publicVariable 'HITMARKERPARAM';
 
-// Broadcast the starting killpoints for everyone
+// Broadcast the starting killpoints and update the HUD for everyone
+[west, RESPAWN_TICKETS] call BIS_fnc_respawnTickets;
 call killPoints_fnc_init;
 
 _dayTimeHours = DAY_TIME_TO - DAY_TIME_FROM;

--- a/server/functions/fn_startServer.sqf
+++ b/server/functions/fn_startServer.sqf
@@ -83,10 +83,12 @@ publicVariable 'HITMARKERPARAM';
 [west, RESPAWN_TICKETS] call BIS_fnc_respawnTickets;
 call killPoints_fnc_init;
 
+// Set time
 _dayTimeHours = DAY_TIME_TO - DAY_TIME_FROM;
 _randTime = floor random _dayTimeHours;
 _timeToSet = DAY_TIME_FROM + _randTime;
-setDate [2018, 7, 1, _timeToSet, 0];
+setDate [2018, SEASON, 21, _timeToSet, 0];
+setTimeMultiplier TIME_MULTIPLIER;
 
 "Starting mission loop" call shared_fnc_log;
 

--- a/shared/Functions.hpp
+++ b/shared/Functions.hpp
@@ -1,26 +1,31 @@
 class shared
 {
-    class sharedFunctions
+    class public
     {
         file = "shared\functions";
 		class log {};
+        class getCurrentParamValue {};
+        class getDefaultParameterSets {};
+        class getDefaultParams {};
+
+    };
+
+    class internal
+    {
+        file = "shared\functions";
         class getNumberFromString {};
         class padString {};
 
         class getProfileParam {};
         class setProfileParam {};
-        class getDefaultParams {};
 
         class loadParameterSet {};
         class saveParameterSet {};
-        class getDefaultParameterSets {};
         class getParameterSets {};
 
         class loadSelectedParameterSet {};
         class saveSelectedParameterSet {};
         class setSavedParameterSets {};
         class getSavedParameterSets {};
-
-        class getCurrentParamValue {};
     };
 };

--- a/shared/bulwark.hpp
+++ b/shared/bulwark.hpp
@@ -44,6 +44,8 @@
 #define BULWARK_PARAM_ARMOUR_WAVE_SCALING       38
 #define BULWARK_PARAM_KILLPOINTS_MODE           39
 #define BULWARK_PARAM_FILTER_FACTIONS           40
+#define BULWARK_PARAM_TIME_MULTIPLIER           41
+#define BULWARK_PARAM_SEASON                    42
 
 // These are known parameter values, and should be named <param name>_<value name>
 // WARNING: If you change these it could mess up the interpretation of people's saved parameters.

--- a/shared/bulwark.hpp
+++ b/shared/bulwark.hpp
@@ -46,6 +46,7 @@
 #define BULWARK_PARAM_FILTER_FACTIONS           40
 #define BULWARK_PARAM_TIME_MULTIPLIER           41
 #define BULWARK_PARAM_SEASON                    42
+#define BULWARK_PARAM_LOCATIONS                 43
 
 // These are known parameter values, and should be named <param name>_<value name>
 // WARNING: If you change these it could mess up the interpretation of people's saved parameters.

--- a/shared/defines.hpp
+++ b/shared/defines.hpp
@@ -34,6 +34,7 @@
 #define PARAM_CATEGORY_START "Start Conditions"
 #define PARAM_CATEGORY_BULWARK "Bulwark Configuration"
 #define PARAM_CATEGORY_GAME "Game Configuration"
+#define PARAM_CATEGORY_TIME "Time and Date"
 #define PARAM_CATEGORY_GEOGRAPHY "Geography"
 #define PARAM_CATEGORY_UPGRADES "Upgrades"
 #define PARAM_CATEGORY_PLAYER "Player Configuration"
@@ -65,7 +66,8 @@
 #define PARAM_HAS_OPTIONS(param) (count (param select PARAM_INDEX_OPTIONS) > 0)
 #define PARAM_GET_OPTIONS(param) (param select PARAM_INDEX_OPTIONS)
 #define PARAM_GET_OPTION_BY_INDEX(param, index) (PARAM_GET_OPTIONS(param) select index)
-#define PARAM_GET_OPTION_BY_ID(param, id) if (true) then { private _optionIndex = (PARAM_GET_OPTIONS(param) findIf { id == PARAM_GET_OPTION_ID(_x)}); if (_optionIndex == -1) then { nil;} else { PARAM_GET_OPTION_BY_INDEX(param, _optionIndex); }; }
+#define PARAM_GET_OPTION_INDEX_FOR_ID(param, id) (PARAM_GET_OPTIONS(param) findIf { id == PARAM_GET_OPTION_ID(_x)})
+#define PARAM_GET_OPTION_BY_ID(param, id) if (true) then { private _optionIndex = PARAM_GET_OPTION_INDEX_FOR_ID(param, id); if (_optionIndex == -1) then { nil;} else { PARAM_GET_OPTION_BY_INDEX(param, _optionIndex); }; }
 #define PARAM_GET_VALUE(param) (param select PARAM_INDEX_VALUE)
 #define PARAM_GET_DESC(param) (param select PARAM_INDEX_DESC)
 

--- a/shared/defines.hpp
+++ b/shared/defines.hpp
@@ -25,7 +25,7 @@
 // Parameters
 //
 #define GET_PARAM_BY_INDEX(params, index) (params select index)
-#define GET_PARAM_BY_ID(params, id) if (true) then { private _paramIndex = (params findIf { id == PARAM_GET_ID(_x) }); if (_paramIndex == -1) then { nil; } else { GET_PARAM_BY_INDEX(params, _paramIndex); };}
+#define GET_PARAM_BY_ID(params, id) call { private _id = id; private _paramIndex = (params findIf { _id == PARAM_GET_ID(_x) }); if (_paramIndex == -1) then { nil; } else { GET_PARAM_BY_INDEX(params, _paramIndex); };}
 #define GET_CURRENT_PARAM_BY_INDEX(index) (CurrentBulwarkParams select index)
 #define GET_CURRENT_PARAM_BY_ID(id) GET_PARAM_BY_ID(CurrentBulwarkParams, id)
 
@@ -66,8 +66,8 @@
 #define PARAM_HAS_OPTIONS(param) (count (param select PARAM_INDEX_OPTIONS) > 0)
 #define PARAM_GET_OPTIONS(param) (param select PARAM_INDEX_OPTIONS)
 #define PARAM_GET_OPTION_BY_INDEX(param, index) (PARAM_GET_OPTIONS(param) select index)
-#define PARAM_GET_OPTION_INDEX_FOR_ID(param, id) (PARAM_GET_OPTIONS(param) findIf { id == PARAM_GET_OPTION_ID(_x)})
-#define PARAM_GET_OPTION_BY_ID(param, id) if (true) then { private _optionIndex = PARAM_GET_OPTION_INDEX_FOR_ID(param, id); if (_optionIndex == -1) then { nil;} else { PARAM_GET_OPTION_BY_INDEX(param, _optionIndex); }; }
+#define PARAM_GET_OPTION_INDEX_FOR_ID(param, id) call { private _id = id; (PARAM_GET_OPTIONS(param) findIf { _id == PARAM_GET_OPTION_ID(_x)}) }
+#define PARAM_GET_OPTION_BY_ID(param, id) call { private _optionIndex = PARAM_GET_OPTION_INDEX_FOR_ID(param, id); if (_optionIndex == -1) then { nil;} else { PARAM_GET_OPTION_BY_INDEX(param, _optionIndex); }; }
 #define PARAM_GET_VALUE(param) (param select PARAM_INDEX_VALUE)
 #define PARAM_GET_DESC(param) (param select PARAM_INDEX_DESC)
 

--- a/shared/defines.hpp
+++ b/shared/defines.hpp
@@ -25,7 +25,7 @@
 // Parameters
 //
 #define GET_PARAM_BY_INDEX(params, index) (params select index)
-#define GET_PARAM_BY_ID(params, id) GET_PARAM_BY_INDEX(params, (params findIf { id == PARAM_GET_ID(_x) }))
+#define GET_PARAM_BY_ID(params, id) if (true) then { private _paramIndex = (params findIf { id == PARAM_GET_ID(_x) }); if (_paramIndex == -1) then { nil; } else { GET_PARAM_BY_INDEX(params, _paramIndex); };}
 #define GET_CURRENT_PARAM_BY_INDEX(index) (CurrentBulwarkParams select index)
 #define GET_CURRENT_PARAM_BY_ID(id) GET_PARAM_BY_ID(CurrentBulwarkParams, id)
 
@@ -52,8 +52,9 @@
 #define PARAM_INDEX_VALUE       6
 #define PARAM_INDEX_DESC        7
 
-#define PARAM_INDEX_OPTION_NAME 0
-#define PARAM_INDEX_OPTION_VALUE 1
+#define PARAM_INDEX_OPTION_ID 0
+#define PARAM_INDEX_OPTION_NAME 1
+#define PARAM_INDEX_OPTION_VALUE 2
 
 // Param Getters
 #define PARAM_GET_ID(param) (param select PARAM_INDEX_ID)
@@ -64,9 +65,11 @@
 #define PARAM_HAS_OPTIONS(param) (count (param select PARAM_INDEX_OPTIONS) > 0)
 #define PARAM_GET_OPTIONS(param) (param select PARAM_INDEX_OPTIONS)
 #define PARAM_GET_OPTION_BY_INDEX(param, index) (PARAM_GET_OPTIONS(param) select index)
+#define PARAM_GET_OPTION_BY_ID(param, id) if (true) then { private _optionIndex = (PARAM_GET_OPTIONS(param) findIf { id == PARAM_GET_OPTION_ID(_x)}); if (_optionIndex == -1) then { nil;} else { PARAM_GET_OPTION_BY_INDEX(param, _optionIndex); }; }
 #define PARAM_GET_VALUE(param) (param select PARAM_INDEX_VALUE)
 #define PARAM_GET_DESC(param) (param select PARAM_INDEX_DESC)
 
+#define PARAM_GET_OPTION_ID(option) (option select PARAM_INDEX_OPTION_ID)
 #define PARAM_GET_OPTION_NAME(option) (option select PARAM_INDEX_OPTION_NAME)
 #define PARAM_GET_OPTION_VALUE(option) (option select PARAM_INDEX_OPTION_VALUE)
 

--- a/shared/functions/fn_getCurrentParamValue.sqf
+++ b/shared/functions/fn_getCurrentParamValue.sqf
@@ -6,13 +6,21 @@ private _value = PARAM_GET_VALUE(_param);
 if (PARAM_IS_MULTISELECT(_param)) then {
     private _values = [];
     {
-        private _option = PARAM_GET_OPTION_BY_INDEX(_param, _value);
-        _values pushBack PARAM_GET_OPTION_VALUE(_option);
+        private _option = PARAM_GET_OPTION_BY_ID(_param, _value);
+        if (!isNil "_option") then {
+            _values pushBack PARAM_GET_OPTION_VALUE(_option);
+        } else {
+            [format ["Failed to find option id %1 for param %2 in multiselect", _value, PARAM_GET_TITLE(_param)], "PARAM"] call shared_fnc_log;
+        };
     } forEach _value;
     _values;
 } else {
     if (PARAM_HAS_OPTIONS(_param)) then {
-        private _option = PARAM_GET_OPTION_BY_INDEX(_param, _value);
+        private _option = PARAM_GET_OPTION_BY_ID(_param, _value);
+        if (isNil "_option") then {
+            [format ["Failed to find option id %1 for param %2. Using first option", _value, PARAM_GET_TITLE(_param)], "PARAM"] call shared_fnc_log;
+            _option = PARAM_GET_OPTION_BY_INDEX(_param, 0);
+        };
         PARAM_GET_OPTION_VALUE(_option);
     } else {
         _value;

--- a/shared/functions/fn_getCurrentParamValue.sqf
+++ b/shared/functions/fn_getCurrentParamValue.sqf
@@ -6,11 +6,11 @@ private _value = PARAM_GET_VALUE(_param);
 if (PARAM_IS_MULTISELECT(_param)) then {
     private _values = [];
     {
-        private _option = PARAM_GET_OPTION_BY_ID(_param, _value);
+        private _option = PARAM_GET_OPTION_BY_ID(_param, _x);
         if (!isNil "_option") then {
             _values pushBack PARAM_GET_OPTION_VALUE(_option);
         } else {
-            [format ["Failed to find option id %1 for param %2 in multiselect", _value, PARAM_GET_TITLE(_param)], "PARAM"] call shared_fnc_log;
+            [format ["Failed to find option id %1 for param %2 in multiselect", _x, PARAM_GET_TITLE(_param)], "PARAM"] call shared_fnc_log;
         };
     } forEach _value;
     _values;

--- a/shared/functions/fn_getDefaultParams.sqf
+++ b/shared/functions/fn_getDefaultParams.sqf
@@ -5,15 +5,7 @@
 // Game parameters
 //
 // These parameters should be specified in the order they will be displayed, and grouped by
-// their category.
-//
-//
-// Parameter format:
-// <parameter id>,
-// <parameter title>, <parameter category name>, <parameter type>, <is multi-select>,
-// <array of options which are title-value pairs>,
-// <default value, or values if multi-select>,
-// <long description of the parameter>
+// their category. See PARAMETERS.md for details.
 //
 
 private _defaultBulwarkParams = [ 
@@ -23,22 +15,40 @@ private _defaultBulwarkParams = [
 	[ 
 		BULWARK_PARAM_FILTER_DLC,
 		"Excluded DLC content", PARAM_CATEGORY_FILTERS, PARAM_TYPE_NUMBER, false, 
-		[ ["None", 0], ["Contact", 1] ], 
+		[ 
+			[0, "None", 0],
+			[1, "Contact", 1]
+		], 
 		0, 
 		"Excludes content from the selected DLCs" 
 	],
 	[ 
 		BULWARK_PARAM_FILTER_PRESET,
 		"Presets", PARAM_CATEGORY_FILTERS, PARAM_TYPE_NUMBER, false, 
-		[ ["Normal", 0], ["WW2 (IFA3_AIO_LITE)", 1], ["Global Mobilization", 2], ["WW2 Winter (IFA_AIO_LITE)", 3], ["WW2 Winter (IFA_AIO_LITE)", 3], ["Custom", 4] ],
+		[
+			[0, "Normal", 0],
+			[1, "WW2 (IFA3_AIO_LITE)", 1],
+			[2, "Global Mobilization", 2],
+			[3, "WW2 Winter (IFA_AIO_LITE)", 3],
+			[4, "Custom", 4]
+		],
 		0, 
 		"Selects from among the set of advanced, detailed mission parameters not present in this list"
 	],
 	[ 
 		BULWARK_PARAM_FILTER_FACTIONS,
 		"Factions", PARAM_CATEGORY_FILTERS, PARAM_TYPE_NUMBER, true, 
-		[["Option 1", 0], ["Option 2", 1], ["Option 3", 2], ["Option 4", 3], ["Option 5", 4], ["Option 6", 5], ["Option 7", 6],["Option 8", 7]],
-		[], 
+		[
+			[0, "Option 1", 0],
+			[1, "Option 2", 1],
+			[2, "Option 3", 2],
+			[3, "Option 4", 3],
+			[4, "Option 5", 4],
+			[5, "Option 6", 5],
+			[6, "Option 7", 6],
+			[7, "Option 8", 7]
+		],
+		[],
 		"Select which factions can spawn as enemies"
 	],
 
@@ -48,77 +58,137 @@ private _defaultBulwarkParams = [
 	[ 
 		BULWARK_PARAM_HOSTILE_MULTIPLIER,
 		"Base hostiles wave multiplier", PARAM_CATEGORY_WAVE, PARAM_TYPE_NUMBER, false,
-		[ ["Reduced", 0.5], ["Normal", 1], ["Double", 2], ["Triple", 3] ], 
+		[
+			[0, "Reduced", 0.5],
+			[1, "Normal", 1],
+			[2, "Double", 2],
+			[3, "Triple", 3]
+		], 
 		1, 
 		"The base number of hostiles generated per wave"
 	],
 	[ 
 		BULWARK_PARAM_HOSTILE_TEAM_MULTIPLIER,
 		"Hostiles per player multiplier", PARAM_CATEGORY_WAVE, PARAM_TYPE_NUMBER, false,
-	    [ ["50%", 50], ["100%", 100], ["150%", 150], ["200%", 200] ],
+	    [
+			[0, "50%", 50],
+			[1, "100%", 100],
+			[2, "150%", 150],
+			[3, "200%", 200]
+		],
 		0,
 		"Additional multiplier on the number of hostiles to add per player"
 	],
 	[
 		BULWARK_PARAM_PISTOL_HOSTILES,
 		"Hostiles restricted to pistols until wave", PARAM_CATEGORY_WAVE, PARAM_TYPE_NUMBER, false,
-		[["Never", 0], ["1", 1], ["2", 2], ["3", 3], ["5", 5], ["10", 10], ["15", 15], ["20", 20], ["25", 25], ["Always", -1]],
+		[
+			[0, "Never", 0], 
+			[1, "1", 1],
+			[2, "2", 2],
+			[3, "3", 3],
+			[4, "5", 5],
+			[5, "10", 10],
+			[6, "15", 15],
+			[7, "20", 20],
+			[8, "25", 25],
+			[9,"Always", -1]
+		],
 		3,
 		"Hostiles will only spawn with pistols until the specified wave"
 	],
 	[
 		BULWARK_PARAM_BODY_CLEANUP,
 		"Dead bodies remain for this many waves", PARAM_CATEGORY_WAVE, PARAM_TYPE_NUMBER, false,
-		[ ["Until the next round", 0], ["1 round", 1], ["2 rounds", 2] ],
+		[
+			[0, "Until the next round", 0],
+			[1, "1 round", 1],
+			[2, "2 rounds", 2]
+		],
 		0,
 		"Dead bodies will remain for the specified number of waves. Higher wave numbers can cause reduced performance and increased lag"
 	],
 	[
 		BULWARK_PARAM_DOWN_TIME,
 		"Down time between waves", PARAM_CATEGORY_WAVE, PARAM_TYPE_NUMBER, false,
-		[ ["No downtime", 0], ["15 seconds", 15], ["30 seconds", 30], ["60 seconds", 60], ["90 seconds", 90], ["2 minutes", 120], ["3 minutes", 180], ["4 minutes", 240], ["5 minutes", 300] ],
+		[
+			[0, "No downtime", 0],
+			[1, "15 seconds", 15],
+			[2, "30 seconds", 30],
+			[3, "60 seconds", 60],
+			[4, "90 seconds", 90],
+			[5, "2 minutes", 120],
+			[6, "3 minutes", 180],
+			[7, "4 minutes", 240],
+			[8, "5 minutes", 300]
+		],
 		3,
 		"There will be this much time between rounds for you to recuperate, build and search"
 	],
 	[
 		BULWARK_PARAM_MAX_WAVES,
 		"Maximum number of waves", PARAM_CATEGORY_WAVE, PARAM_TYPE_NUMBER, false,
-		[ ["No limit", 0], ["20 waves", 20], ["30 waves", 30], ["40 waves", 40] ],
+		[
+			[0, "No limit", 0],
+			[1, "20 waves", 20],
+			[2, "30 waves", 30],
+			[3, "40 waves", 40]
+		],
 		0,
 		"The game will end after this many waves"
 	],
 	[
 		BULWARK_PARAM_SPECIAL_WAVES,
 		"Special waves?", PARAM_CATEGORY_WAVE, PARAM_TYPE_NUMBER, false,
-		[["No", 0], ["Yes", 1]],
+		[
+			[0, "No", 0],
+			[1, "Yes", 1]
+		],
 		1,
 		"Should there be special waves, such as suicide bombers, night time, dense fog, etc. after the first few waves?"
 	],
 	[
 		BULWARK_PARAM_SPECIAL_WAVES_ONLY,
 		"Only special waves?", PARAM_CATEGORY_WAVE, PARAM_TYPE_NUMBER, false,
-		[["No", 0], ["Yes", 1]],
+		[
+			[0, "No", 0],
+			[1, "Yes", 1]
+		],
 		0,
 		"Should there be only be special waves after the first few waves?"
 	],
 	[
 		BULWARK_PARAM_SPECIAL_WAVES_VARIETY,
 		"Increase special wave variety?", PARAM_CATEGORY_WAVE, PARAM_TYPE_NUMBER, false,
-		[["No", 0], ["Yes", 1]],
+		[
+			[0, "No", 0],
+			[1, "Yes", 1]],
 		1,
 		"Should there be less chance of repeating the same special wave type?"
 	],
 	[
 		BULWARK_PARAM_ARMOUR_START_WAVE,
 		"Vehicles may spawn after wave", PARAM_CATEGORY_WAVE, PARAM_TYPE_NUMBER, false,
-		[["Never", 0], ["5", 5], ["10", 10], ["15", 15], ["20", 20], ["25", 25]],
+		[
+			[0, "Never", 0],
+			[1, "5", 5],
+			[2, "10", 10],
+			[3, "15", 15],
+			[4, "20", 20],
+			[5, "25", 25]
+		],
 		1,
 		"Vehicles will start to spawn after the specified wave?"
 	],
 	[
 		BULWARK_PARAM_ARMOUR_WAVE_SCALING,
 		"Armor spawn budget", PARAM_CATEGORY_WAVE, PARAM_TYPE_NUMBER, false,
-		[["50%", 0.2], ["100%", 0.4], ["150%", 0.6], ["200%", 0.8]],
+		[
+			[0, "50%", 0.2],
+			[1, "100%", 0.4],
+			[2, "150%", 0.6],
+			[3, "200%", 0.8]
+		],
 		1,
 		"Controls how much budget is available for spawning vehicles.  Higher means more and more powerful vehicles."
 	],
@@ -129,21 +199,30 @@ private _defaultBulwarkParams = [
 	[
 		BULWARK_PARAM_PLAYER_STARTMAP,
 		"Start with a map?", PARAM_CATEGORY_START, PARAM_TYPE_NUMBER, false,
-		[ ["No", 0], ["Yes", 1]],
+		[ 
+			[0, "No", 0],
+			[1, "Yes", 1]
+		],
 		1,
 		"Should players start with a map in their inventory?"
 	],
 	[
 		BULWARK_PARAM_PLAYER_STARTWEAPON,
 		"Start with a pistol?", PARAM_CATEGORY_START, PARAM_TYPE_NUMBER, false,
-		[ ["No", 0], ["Yes", 1]],
+		[
+			[0, "No", 0],
+			[1, "Yes", 1]
+		],
 		0,
 		"Should players start with a pistol in their inventory?"
 	],
 	[
 		BULWARK_PARAM_PLAYER_STARTNVG,
 		"Start with NVGs?", PARAM_CATEGORY_START, PARAM_TYPE_NUMBER, false,
-		[ ["No", 0], ["Yes", 1]],
+		[
+			[0, "No", 0],
+			[1, "Yes", 1]
+		],
 		0,
 		"Should players start with NVGs in their inventory?"
 	],
@@ -154,56 +233,106 @@ private _defaultBulwarkParams = [
 	[
 		BULWARK_PARAM_RANDOM_WEAPONS,
 		"Randomize hostile weapons?", PARAM_CATEGORY_GAME, PARAM_TYPE_NUMBER, false,
-		[ ["No", 0], ["Yes", 1]],
+		[
+			[0, "No", 0],
+			[1, "Yes", 1]
+		],
 		0,
 		"Should enemies have completely randomized weapons?"
 	],
 	[
 		BULWARK_PARAM_HUD_POINT_HITMARKERS,
 		"Point hitmarkers on HUD?", PARAM_CATEGORY_GAME, PARAM_TYPE_NUMBER, false,
-		[ ["No", 0], ["Yes", 1]],
+		[
+			[0, "No", 0],
+			[1, "Yes", 1]
+		],
 		1,
 		"Should there be hit markers on the HUD?"
 	],
 	[
 		BULWARK_PARAM_LOOT_HOUSE_DENSITY,
 		"Minimum buildings near bulwark", PARAM_CATEGORY_GAME, PARAM_TYPE_NUMBER, false,
-		[ ["5", 5], ["10", 10], ["15", 15], ["20", 20], ["25", 25], ["30", 30]],
+		[
+			[0, "5", 5],
+			[1, "10", 10],
+			[2, "15", 15],
+			[3, "20", 20],
+			[4, "25", 25],
+			[5, "30", 30]
+		],
 		1,
 		"The minimum number of buildings which must be near the bulwark to be considered a valid starting location"
 	],
 	[
 		BULWARK_PARAM_LOOT_HOUSE_DISTRIBUTION,
 		"Loot distribution", PARAM_CATEGORY_GAME, PARAM_TYPE_NUMBER, false,
-		[ ["Every building", 1], ["Every second building", 2], ["Every third building", 3], ["Every fourth building", 4]],
+		[
+			[0, "Every building", 1],
+			[1, "Every second building", 2],
+			[2, "Every third building", 3],
+			[3, "Every fourth building", 4]
+		],
 		1,
 		"This determines which buildings will spawn loot"
 	],
 	[
 		BULWARK_PARAM_LOOT_ROOM_DISTRIBUTION,
 		"Loot density", PARAM_CATEGORY_GAME, PARAM_TYPE_NUMBER, false,
-		[ ["Every location", 1], ["Every second location", 2], ["Every third location", 3], ["Every fourth location", 4]],
+		[
+			[0, "Every location", 1],
+			[1, "Every second location", 2],
+			[2, "Every third location", 3],
+			[3, "Every fourth location", 4]
+		],
 		1,
 		"This determines which locations within a building will spawn loot"
 	],
 	[
 		BULWARK_PARAM_LOOT_SUPPLYDROP,
 		"Supply drop distance", PARAM_CATEGORY_GAME, PARAM_TYPE_NUMBER, false,
-		[ ["Center", 0], ["Within 25% radius", 25], ["Within 50% radius", 50], ["Within 75% radius", 75]],
+		[
+			[0, "Center", 0],
+			[1, "Within 25% radius", 25],
+			[2, "Within 50% radius", 50],
+			[3, "Within 75% radius", 75]
+		],
 		1,
 		"This determines how far from the center of the mission area supply crates will drop"
 	],
 	[
 		BULWARK_PARAM_DAY_TIME_FROM,
 		"Earliest mission time start", PARAM_CATEGORY_GAME, PARAM_TYPE_NUMBER, false,
-		[ ["0200 hours", 2], ["0400 hours", 4], ["0600 hours", 6], ["0800 hours", 8], ["1000 hours", 10], ["1200 hours", 12], ["1400 hours", 14], ["1600 hours", 16], ["1800 hours", 18], ["2000 hours", 20]],
+		[
+			[0, "0200 hours", 2],
+			[1, "0400 hours", 4],
+			[2, "0600 hours", 6],
+			[3, "0800 hours", 8],
+			[4, "1000 hours", 10],
+			[5, "1200 hours", 12],
+			[6, "1400 hours", 14],
+			[7, "1600 hours", 16],
+			[8, "1800 hours", 18],
+			[9, "2000 hours", 20]
+		],
 		3,
 		"The earliest time of dat the mission will start"
 	],
 	[
 		BULWARK_PARAM_DAY_TIME_TO,
 		"Latest mission time start", PARAM_CATEGORY_GAME, PARAM_TYPE_NUMBER, false,
-		[ ["0200 hours", 2], ["0400 hours", 4], ["0600 hours", 6], ["0800 hours", 8], ["1000 hours", 10], ["1200 hours", 12], ["1400 hours", 14], ["1600 hours", 16], ["1800 hours", 18], ["2000 hours", 20]],
+		[
+			[0, "0200 hours", 2],
+			[1, "0400 hours", 4],
+			[2, "0600 hours", 6],
+			[3, "0800 hours", 8],
+			[4, "1000 hours", 10],
+			[5, "1200 hours", 12],
+			[6, "1400 hours", 14],
+			[7, "1600 hours", 16],
+			[8, "1800 hours", 18],
+			[9, "2000 hours", 20]
+		],
 		7,
 		"The latest time of day the mission will start"
 	],
@@ -214,28 +343,49 @@ private _defaultBulwarkParams = [
 	[
 		BULWARK_PARAM_BULWARK_RADIUS,
 		"Mission area size", PARAM_CATEGORY_GEOGRAPHY, PARAM_TYPE_NUMBER, false,
-		[ ["Tiny (50m)", 50], ["Small (100m)", 100], ["Normal (150m)", 150], ["Large (200m)", 200], ["Huge (250m)", 250] ],
+		[
+			[0, "Tiny (50m)", 50],
+			[1, "Small (100m)", 100],
+			[2, "Normal (150m)", 150],
+			[3, "Large (200m)", 200],
+			[4, "Huge (250m)", 250]
+		],
 		2,
 		"This is the mission area radius be around the start area"
 	],
 	[
 		BULWARK_PARAM_BULWARK_MINSIZE,
 		"Minimum spawn room size", PARAM_CATEGORY_GEOGRAPHY, PARAM_TYPE_NUMBER, false,
-		[ ["10m²", 10], ["13m²", 13], ["15m²", 15], ["18m²", 18], ["20m²", 20] ],
+		[
+			[0, "10m²", 10],
+			[1, "13m²", 13],
+			[2, "15m²", 15],
+			[3, "18m²", 18],
+			[4, "20m²", 20]
+		],
 		1,
 		"This is the minimum size the spawn room will be"
 	],
 	[
 		BULWARK_PARAM_LANDRATIO,
 		"Minimum land/water ratio", PARAM_CATEGORY_GEOGRAPHY, PARAM_TYPE_NUMBER, false,
-		[ ["60%", 60], ["70%", 70], ["80%", 80], ["90%", 90], ["100%", 100] ],
+		[
+			[0, "60%", 60],
+			[1, "70%", 70],
+			[2, "80%", 80],
+			[3, "90%", 90],
+			[4, "100%", 100]
+		],
 		2,
 		"This is the minimum ratio of land to water, to avoid spawning on a dock of pier"
 	],
 	[
 		BULWARK_PARAM_BULWARK_POSITION,
 		"Starting position", PARAM_CATEGORY_GEOGRAPHY, PARAM_TYPE_NUMBER, false,
-		[ ["Near a town", 0], ["Random marker", 1] ],
+		[
+			[0, "Near a town", 0],
+			[1, "Random marker", 1]
+		],
 		0,
 		"Determines whether the start area will be chosen at random or from among a selection of pre-defined marked locations for this map"
 	],
@@ -257,14 +407,21 @@ private _defaultBulwarkParams = [
 	[
 		BULWARK_PARAM_SUPPORT_MENU,
 		"Upgrades require Satellite dish", PARAM_CATEGORY_UPGRADES, PARAM_TYPE_NUMBER, false,
-		[["No", 0], ["Yes", 1]],
+		[
+			[0, "No", 0],
+			[1, "Yes", 1]
+		],
 		1,
 		"Do upgrades require the Satellite dish to have been found?"
 	],
 	[
 		BULWARK_PARAM_KILLPOINTS_MODE,
 		"How kill points are distributed", PARAM_CATEGORY_UPGRADES, PARAM_TYPE_NUMBER, false,
-		[["Personal", KILLPOINTS_MODE_PRIVATE], ["Shared", KILLPOINTS_MODE_SHARED], ["Shareable", KILLPOINTS_MODE_SHAREABLE]],
+		[
+			[0, "Personal", KILLPOINTS_MODE_PRIVATE],
+			[1, "Shared", KILLPOINTS_MODE_SHARED],
+			[2, "Shareable", KILLPOINTS_MODE_SHAREABLE]
+		],
 		0,
 		"Kill points can either be personal, shared among all players, or shared manually by players."
 	],
@@ -278,28 +435,53 @@ private _defaultBulwarkParams = [
 	[
 		BULWARK_PARAM_SCORE_KILL,
 		"Points per kill", PARAM_CATEGORY_UPGRADES, PARAM_TYPE_NUMBER, false,
-		[ ["10", 10], ["50", 50], ["100", 100], ["200", 200], ["300, 300"]],
+		[
+			[0, "10", 10],
+			[1, "50", 50],
+			[2, "100", 100],
+			[3, "200", 200],
+			[4, "300", 300]
+		],
 		2,
 		"The number of points awarded for each confirmed kill"
 	],
 	[
 		BULWARK_PARAM_SCORE_HIT,
 		"Points per hit", PARAM_CATEGORY_UPGRADES, PARAM_TYPE_NUMBER, false,
-		[["0", 0], ["10", 10], ["20", 20], ["50", 50], ["100", 100]],
+		[
+			[0, "0", 0],
+			[1, "10", 10],
+			[2, "20", 20],
+			[3, "50", 50],
+			[4, "100", 100]
+		],
 		2,
 		"The number of bonus points awarded for each hit"
 	],
 	[
 		BULWARK_PARAM_SCORE_DAMAGE_BASE,
 		"Damage bonus points", PARAM_CATEGORY_UPGRADES, PARAM_TYPE_NUMBER, false,
-		[["0", 0], ["10", 10], ["20", 20], ["50", 50], ["100", 100]],
+		[
+			[0, "0", 0],
+			[1, "10", 10],
+			[2, "20", 20],
+			[3, "50", 50],
+			[4, "100", 100]
+		],
 		2,
 		"The number of bonus points awarded for extra damage"
 	],
 	[
 		BULWARK_PARAM_PARATROOP_COUNT,
 		"Paratrooper count", PARAM_CATEGORY_UPGRADES, PARAM_TYPE_NUMBER, false,
-		[["1", 1], ["2", 2], ["3", 3], ["4", 4], ["5", 5], ["6", 6]],
+		[
+			[0, "1", 1],
+			[1, "2", 2],
+			[2, "3", 3],
+			[3, "4", 4],
+			[4, "5", 5],
+			[5, "6", 6]
+		],
 		2,
 		"The number of paratroopers dropped when called"
 	],
@@ -310,7 +492,11 @@ private _defaultBulwarkParams = [
 	[
 		BULWARK_PARAM_REVIVE_ITEMS,
 		"Revive required items", PARAM_CATEGORY_PLAYER, PARAM_TYPE_NUMBER, false,
-		[ ["None", 0], ["Medikit", 1], ["FAK or Medikit", 2]],
+		[
+			[0, "None", 0],
+			[1, "Medikit", 1],
+			[2, "FAK or Medikit", 2]
+		],
 		2,
 		"The items which are required to revive another player"
 		// TODO 	function = "bis_fnc_paramReviveRequiredItems";
@@ -318,33 +504,39 @@ private _defaultBulwarkParams = [
 	[
 		BULWARK_PARAM_RESPAWN_TICKETS,
 		"Respawn tickets", PARAM_CATEGORY_PLAYER, PARAM_TYPE_NUMBER, false,
-		[ ["0", 0], ["5", 5], ["10", 10], ["15", 15], ["20", 20]],
+		[
+			[0, "0", 0],
+			[1, "5", 5],
+			[2, "10", 10],
+			[3, "15", 15],
+			[4, "20", 20]
+		],
 		0,
 		"The number of respawn tickets"
 	],
 	[
 		BULWARK_PARAM_RESPAWN_TIME,
 		"Respawn time", PARAM_CATEGORY_PLAYER, PARAM_TYPE_NUMBER, false,
-		[ ["Instant", 0], ["5 seconds", 5], ["10 seconds", 10], ["20 seconds", 20], ["30 seconds", 30]],
+		[
+			[0, "Instant", 0],
+			[1, "5 seconds", 5],
+			[2, "10 seconds", 10],
+			[3, "20 seconds", 20],
+			[4, "30 seconds", 30]
+		],
 		2,
 		"The amount of time after using a ticket before the player respawns"
 	],
 	[
 		BULWARK_PARAM_TEAM_DAMAGE,
 		"Enable friendly fire?", PARAM_CATEGORY_PLAYER, PARAM_TYPE_NUMBER, false,
-		[ ["No", 0], ["Yes", 1] ],
+		[
+			[0, "No", 0],
+			[1, "Yes", 1]
+		],
 		1,
 		"Whether or not friendly-fire is enabled"
 	]
-
 ];
-
-	// TODO
-	// class FILTER_PRESET
-	// {
-	// 	values[] = {0,1,2,3,4};
-	// 	texts[] = {"Normal","WW2 (IFA3_AIO_LITE)","Global Mobilization","WW2 Winter (IFA_AIO_LITE)","Custom (same as Normal by default, its for you to mess around in)"};
-	// 	default = 0;
-	// };
 
 _defaultBulwarkParams;

--- a/shared/functions/fn_getDefaultParams.sqf
+++ b/shared/functions/fn_getDefaultParams.sqf
@@ -300,10 +300,15 @@ private _defaultBulwarkParams = [
 		1,
 		"This determines how far from the center of the mission area supply crates will drop"
 	],
+
+	//
+	// PARAM_CATEGORY_TIME
+	//
 	[
 		BULWARK_PARAM_DAY_TIME_FROM,
-		"Earliest mission time start", PARAM_CATEGORY_GAME, PARAM_TYPE_NUMBER, false,
+		"Earliest mission time start", PARAM_CATEGORY_TIME, PARAM_TYPE_NUMBER, false,
 		[
+			[11, "0000 hours", 0],
 			[0, "0200 hours", 2],
 			[1, "0400 hours", 4],
 			[2, "0600 hours", 6],
@@ -313,15 +318,17 @@ private _defaultBulwarkParams = [
 			[6, "1400 hours", 14],
 			[7, "1600 hours", 16],
 			[8, "1800 hours", 18],
-			[9, "2000 hours", 20]
+			[9, "2000 hours", 20],
+			[10, "2200 hours", 22]
 		],
 		3,
 		"The earliest time of dat the mission will start"
 	],
 	[
 		BULWARK_PARAM_DAY_TIME_TO,
-		"Latest mission time start", PARAM_CATEGORY_GAME, PARAM_TYPE_NUMBER, false,
+		"Latest mission time start", PARAM_CATEGORY_TIME, PARAM_TYPE_NUMBER, false,
 		[
+			[11, "0000 hours", 0],
 			[0, "0200 hours", 2],
 			[1, "0400 hours", 4],
 			[2, "0600 hours", 6],
@@ -331,10 +338,37 @@ private _defaultBulwarkParams = [
 			[6, "1400 hours", 14],
 			[7, "1600 hours", 16],
 			[8, "1800 hours", 18],
-			[9, "2000 hours", 20]
+			[9, "2000 hours", 20],
+			[10, "2200 hours", 22]
 		],
 		7,
 		"The latest time of day the mission will start"
+	],
+	[
+		BULWARK_PARAM_SEASON,
+		"Season to play in", PARAM_CATEGORY_TIME, PARAM_TYPE_NUMBER, false,
+		[
+			[0, "Spring", 3],
+			[1, "Summer", 6],
+			[2, "Fall", 9],
+			[3, "Winter", 12]
+		],
+		1,
+		"The season in which the game will be played"
+	],
+	[
+		BULWARK_PARAM_TIME_MULTIPLIER,
+		"Time multiplier", PARAM_CATEGORY_TIME, PARAM_TYPE_NUMBER, false,
+		[
+			[0, "Real-time", 3],
+			[1, "1hr/10 min", 6],
+			[2, "1hr/5 min", 12],
+			[3, "1hr/3 min", 20],
+			[4, "1hr/2 min", 30],
+			[5, "1hr/1 min", 60]
+		],
+		0,
+		"The rate at which game time passes. Note church bells ring every 15 minutes game time..."
 	],
 
 	//

--- a/shared/functions/fn_getDefaultParams.sqf
+++ b/shared/functions/fn_getDefaultParams.sqf
@@ -417,11 +417,23 @@ private _defaultBulwarkParams = [
 		BULWARK_PARAM_BULWARK_POSITION,
 		"Starting position", PARAM_CATEGORY_GEOGRAPHY, PARAM_TYPE_NUMBER, false,
 		[
-			[0, "Near a town", 0],
+			[0, "Random map location", 0],
 			[1, "Random marker", 1]
 		],
 		0,
-		"Determines whether the start area will be chosen at random or from among a selection of pre-defined marked locations for this map"
+		"Determines whether the start area will be chosen at random from locations on the map or from among a selection of pre-defined marked locations"
+	],
+	[
+		BULWARK_PARAM_LOCATIONS,
+		"Random map locations", PARAM_CATEGORY_GEOGRAPHY, PARAM_TYPE_NUMBER, true,
+		[
+			[0, "Capital Cities", "NameCityCapital"],
+			[1, "Major Cities", "NameCity"],
+			[2, "Small Towns", "NameVillage"],
+			[3, "Building Clusters", "NameLocal"]
+		],
+		[0, 1, 2],
+		"When the Starting Position is a random map location, which locations should be considered?"
 	],
 
 	//

--- a/supports/functions/fn_supplyDrop.sqf
+++ b/supports/functions/fn_supplyDrop.sqf
@@ -60,7 +60,7 @@ _agVehicle animateDoor ['Door_1_source', 1];
 waitUntil {supplyDropLatch};
 
 // Drop cargo
-private _parachutePos = (getPosATL _agVehicle) vectorAdd [0, 0, -5]; // Start 5 meters below the plane, to avoid collisions
+private _parachutePos = (getPosATL _agVehicle) vectorAdd [0, 0, -8]; // Start 8 meters below the plane, to avoid collisions
 _parachute = createVehicle ["B_Parachute_02_F", _parachutePos, [], 0, "NONE"];
 _supplyBox = createVehicle ["Land_WoodenCrate_01_F", [0,0,0], [], 0, "CAN_COLLIDE"];
 _supplyBox attachTo [_parachute, [0,0,0]];


### PR DESCRIPTION
Option lists in parameters are now associative arrays, and so the parameter value references the new ID field of the option, not its position in the index.  This lets the options be reordered or removed without causing issues.
Added ability to select season to play in.
Added ability to select time speed multiplier, allowing faster day/night cycles.
Fix tight mission loop - improved performance
Fix issue with supply drop sometimes clipping parachute
Added ability to select which class of locations are candidate start areas