### PR TITLE
Improve loot and spawn building selection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,7 @@
 * Spawns between waves?
 * "Shareable" bulwark points (player can choose to give another player some of their points)
 * Progressived spawning (cap on how many units can spawn at once, trickle them in over time)
-* Broaden search for valid starting houses/loot houses.  Seems like we are always getting the same couple of cities
+
 * Use CBA logging mechanism: https://github.com/CBATeam/CBA_A3/wiki/Error-handling
 * Ability to sell back items (User suggested)
 
@@ -47,3 +47,4 @@
 * DONE Ability to set time multiplier (for faster day/night cycles)
 * FIXED Long start time for some waves
 * FIXED missionLoop is a tight while loop
+* ADDED Ability to select which set of locations are candidates for starting

--- a/bulwark/createBase.sqf
+++ b/bulwark/createBase.sqf
@@ -137,7 +137,8 @@ _marker1 = createMarker ["Mission Area", bulwarkCity];
 "Mission Area" setMarkerSize [BULWARK_RADIUS, BULWARK_RADIUS];
 "Mission Area" setMarkerColor "ColorWhite";
 
-lootHouses = bulwarkCity nearObjects ["House", BULWARK_RADIUS];
+// Candidate houses must be within the radius and have at least one room
+lootHouses = (bulwarkCity nearObjects ["Building", BULWARK_RADIUS]) select { count (_x buildingPos -1) > 0 };
 
 /* Spinner Box */
 

--- a/bulwark/functions/fn_bulwarkLocation.sqf
+++ b/bulwark/functions/fn_bulwarkLocation.sqf
@@ -10,8 +10,9 @@ if (BULWARK_LOCATIONS_MARKER) then {
 _probe = createVehicle ["Sign_Arrow_F", [0,0,0], [], 0, "CAN_COLLIDE"];
 while {isNil "_finalPos"} do {
 	_city = selectRandom _locations;
-	_houses = nearestObjects [_city, ["house"], 300];
 
+	// Consider houses which are within 300 meters of the specified city and have at least one actual room.
+	_houses = (nearestObjects [_city, ["Building"], 300]) select { count (_x buildingPos -1) > 0 };
 	_options = [];
 
 	// Go through every house and position
@@ -34,7 +35,7 @@ while {isNil "_finalPos"} do {
 		} forEach (_house buildingPos -1);
 
 		// Make sure it's not some crapshack in the middle of nowhere
-		_neighbours = count nearestObjects [_largestPos, ["house"], BULWARK_RADIUS];
+		_neighbours = count ((nearestObjects [_largestPos, ["house"], BULWARK_RADIUS]) select { count (_x buildingPos -1) > 0 });
 
 		// One house, one location. Add it to the list of options
 		if(_largestVolume > 0 && _neighbours > LOOT_HOUSE_DENSITY) then {


### PR DESCRIPTION
We now consider all buildings (not just houses), as long as they have at least one actual location in them.